### PR TITLE
stub _open syscall for strptime

### DIFF
--- a/os/various/syscalls.c
+++ b/os/various/syscalls.c
@@ -121,6 +121,17 @@ int _write_r(struct _reent *r, int file, char * ptr, int len)
 /***************************************************************************/
 
 __attribute__((used))
+int _open_r(struct _reent *r, int file)
+{
+  (void)r;
+  (void)file;
+
+  return 0;
+}
+
+/***************************************************************************/
+
+__attribute__((used))
 int _close_r(struct _reent *r, int file)
 {
   (void)r;


### PR DESCRIPTION
we needed `_open_r` to get `strptime` working. Not sure why it wasn't stubbed in the first place.

note that simply stubbing `_open_r` did not make `strftime` work, but I didn't do any digging as to why